### PR TITLE
leiden nmi ari

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,8 @@
     :toctree: generated
 
     isolated_labels
-    nmi_ari_cluster_labels
+    nmi_ari_cluster_labels_kmeans
+    nmi_ari_cluster_labels_leiden
     silhouette_label
     silhouette_batch
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "scikit-learn",
     "scanpy",
     "rich",
+    "igraph>0.9.0"
 ]
 
 [project.optional-dependencies]
@@ -49,6 +50,10 @@ doc = [
 test = [
     "pytest",
     "pytest-cov",
+    "joblib",
+]
+parallel = [
+    "joblib"
 ]
 
 [tool.coverage.run]

--- a/src/scib_metrics/__init__.py
+++ b/src/scib_metrics/__init__.py
@@ -2,7 +2,7 @@ import logging
 from importlib.metadata import version
 
 from . import utils
-from ._ari_nmi import nmi_ari_cluster_labels
+from ._ari_nmi import nmi_ari_cluster_labels_kmeans, nmi_ari_cluster_labels_leiden
 from ._isolated_labels import isolated_labels
 from ._settings import settings
 from ._silhouette import silhouette_batch, silhouette_label
@@ -12,7 +12,8 @@ __all__ = [
     "isolated_labels",
     "silhouette_label",
     "silhouette_batch",
-    "nmi_ari_cluster_labels",
+    "nmi_ari_cluster_labels_kmeans",
+    "nmi_ari_cluster_labels_leiden",
 ]
 
 __version__ = version("scib-metrics")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,8 +6,10 @@ from sklearn.metrics import silhouette_samples as sk_silhouette_samples
 import scib_metrics
 
 
-def dummy_x_labels():
+def dummy_x_labels(return_symmetric_positive=False):
     X = np.array([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]])
+    if return_symmetric_positive:
+        X = np.abs(X @ X.T)
     labels = np.array([0, 0, 1, 1, 0, 1])
     return X, labels
 
@@ -47,9 +49,23 @@ def test_silhouette_batch():
     scib_metrics.silhouette_batch(X, labels, batch)
 
 
-def test_nmi_ari_cluster_labels():
+def test_nmi_ari_cluster_labels_kmeans():
     X, labels = dummy_x_labels()
-    nmi, ari = scib_metrics.nmi_ari_cluster_labels(X, labels)
+    nmi, ari = scib_metrics.nmi_ari_cluster_labels_kmeans(X, labels)
+    assert isinstance(nmi, float)
+    assert isinstance(ari, float)
+
+
+def test_nmi_ari_cluster_labels_leiden_parallel():
+    X, labels = dummy_x_labels(return_symmetric_positive=True)
+    nmi, ari = scib_metrics.nmi_ari_cluster_labels_leiden(X, labels, optimize_resolution=True, n_jobs=2)
+    assert isinstance(nmi, float)
+    assert isinstance(ari, float)
+
+
+def test_nmi_ari_cluster_labels_leiden_single_resolution():
+    X, labels = dummy_x_labels(return_symmetric_positive=True)
+    nmi, ari = scib_metrics.nmi_ari_cluster_labels_leiden(X, labels, optimize_resolution=False, resolution=0.1)
     assert isinstance(nmi, float)
     assert isinstance(ari, float)
 


### PR DESCRIPTION
Adds leiden nmi ari scores to more closely match scib (they use louvain). This does a search of 10 resolutions of leiden clustering to pick the optimal NMI (as in scIB, but it uses 20 res params)