### PR TITLE
Lax'd/mapped silhouette and squareform pdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ test = [
     "pytest-cov",
     "harmonypy",
     "joblib",
+    "flake8",
+    "black",
 ]
 parallel = [
     "joblib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ test = [
     "pytest-cov",
     "harmonypy",
     "joblib",
+    # For vscode Python extension testing
     "flake8",
     "black",
 ]

--- a/src/scib_metrics/_settings.py
+++ b/src/scib_metrics/_settings.py
@@ -98,6 +98,10 @@ class ScibConfig:
         ch.setFormatter(formatter)
         scib_logger.addHandler(ch)
 
+    def jax_fix_no_kernel_image(self) -> None:
+        """Fix for JAX error "No kernel image is available for execution on the device"."""
+        os.environ["XLA_FLAGS"] = "--xla_gpu_force_compilation_parallelism=1"
+
     @property
     def jax_preallocate_gpu_memory(self):
         """Jax GPU memory allocation settings.

--- a/src/scib_metrics/utils/__init__.py
+++ b/src/scib_metrics/utils/__init__.py
@@ -1,6 +1,6 @@
-from ._dist import cdist
+from ._dist import cdist, pdist_squareform
 from ._kmeans import KMeansJax
 from ._lisi import compute_simpson_index
 from ._silhouette import silhouette_samples
 
-__all__ = ["silhouette_samples", "cdist", "KMeansJax", "compute_simpson_index"]
+__all__ = ["silhouette_samples", "cdist", "pdist_squareform", "KMeansJax", "compute_simpson_index"]

--- a/src/scib_metrics/utils/__init__.py
+++ b/src/scib_metrics/utils/__init__.py
@@ -5,4 +5,13 @@ from ._pca import pca
 from ._silhouette import silhouette_samples
 from ._utils import get_ndarray, one_hot
 
-__all__ = ["silhouette_samples", "cdist", "pdist_squareform", "get_ndarray", "KMeansJax", "pca", "one_hot", "compute_simpson_index"]
+__all__ = [
+    "silhouette_samples",
+    "cdist",
+    "pdist_squareform",
+    "get_ndarray",
+    "KMeansJax",
+    "pca",
+    "one_hot",
+    "compute_simpson_index",
+]

--- a/src/scib_metrics/utils/_dist.py
+++ b/src/scib_metrics/utils/_dist.py
@@ -28,3 +28,29 @@ def cdist(x: np.ndarray, y: np.ndarray) -> jnp.ndarray:
         Array of shape (n_cells_a, n_cells_b)
     """
     return jax.vmap(lambda x1: jax.vmap(lambda y1: _euclidean_distance(x1, y1))(y))(x)
+
+
+@jax.jit
+def pdist_squareform(X: np.ndarray) -> jnp.ndarray:
+    """Jax implementation of :func:`scipy.spatial.distance.pdist` and :func:`scipy.spatial.distance.squareform`.
+
+    Uses euclidean distance.
+
+    Parameters
+    ----------
+    X
+        Array of shape (n_cells, n_features)
+
+    Returns
+    -------
+    dist
+        Array of shape (n_cells, n_cells)
+    """
+    n_cells = X.shape[0]
+    inds = jnp.triu_indices(n_cells)
+    dist_mat = jnp.zeros((n_cells, n_cells))
+    dist_mat = dist_mat.at[inds].set(
+        jax.vmap(lambda i, j, X: _euclidean_distance(X[i], X[j]), in_axes=(0, 0, None))(*inds, jnp.asarray(X))
+    )
+    dist_mat = jnp.maximum(dist_mat, dist_mat.T)
+    return dist_mat

--- a/src/scib_metrics/utils/_dist.py
+++ b/src/scib_metrics/utils/_dist.py
@@ -46,11 +46,12 @@ def pdist_squareform(X: np.ndarray) -> jnp.ndarray:
     dist
         Array of shape (n_cells, n_cells)
     """
-    n_cells = X.shape[0]
-    inds = jnp.triu_indices(n_cells)
-    dist_mat = jnp.zeros((n_cells, n_cells))
-    dist_mat = dist_mat.at[inds].set(
-        jax.vmap(lambda i, j, X: _euclidean_distance(X[i], X[j]), in_axes=(0, 0, None))(*inds, jnp.asarray(X))
-    )
-    dist_mat = jnp.maximum(dist_mat, dist_mat.T)
-    return dist_mat
+    # TODO(adamgayoso): Figure out how to speed up something like this
+    # n_cells = X.shape[0]
+    # inds = jnp.triu_indices(n_cells)
+    # dist_mat = jnp.zeros((n_cells, n_cells))
+    # dist_mat = dist_mat.at[inds].set(
+    #     jax.vmap(lambda i, j, X: _euclidean_distance(X[i], X[j]), in_axes=(0, 0, None))(*inds, jnp.asarray(X))
+    # )
+    # dist_mat = jnp.maximum(dist_mat, dist_mat.T)
+    return cdist(X, X)

--- a/src/scib_metrics/utils/_silhouette.py
+++ b/src/scib_metrics/utils/_silhouette.py
@@ -64,7 +64,7 @@ def _nearest_cluster_distance_block(subset_a: jnp.ndarray, subset_b: jnp.ndarray
     distances = cdist(subset_a, subset_b)
     masked_distances = jnp.where(full_mask, distances, 0)
     values_a = masked_distances.sum(axis=1)
-    values_b = jnp.where(full_mask, distances, 0).sum(axis=0)
+    values_b = masked_distances.sum(axis=0)
     real_cells_in_subset_a = mask_a.sum()
     real_cells_in_subset_b = mask_b.sum()
     values_a /= real_cells_in_subset_b

--- a/src/scib_metrics/utils/_silhouette.py
+++ b/src/scib_metrics/utils/_silhouette.py
@@ -46,13 +46,12 @@ def _intra_cluster_distances_block(subset: jnp.ndarray) -> jnp.ndarray:
 # @jax.jit
 def _nearest_cluster_distances(X: jnp.ndarray, inds: jnp.ndarray = None) -> jnp.ndarray:
     """Calculate the mean nearest-cluster distance for observation i."""
-    carry = 0
 
-    def _body_fn(carry, inds):
+    def _body_fn(inds):
         i, j = inds
-        return carry, _nearest_cluster_distance_block(X[i], X[j])
+        return _nearest_cluster_distance_block(X[i], X[j])
 
-    _, inter_dist = jax.lax.scan(_body_fn, carry, (inds[0], inds[1]))
+    inter_dist = jax.lax.map(_body_fn, (inds[0], inds[1]))
     return inter_dist
 
 

--- a/src/scib_metrics/utils/_silhouette.py
+++ b/src/scib_metrics/utils/_silhouette.py
@@ -44,7 +44,7 @@ def _intra_cluster_distances_block(subset: jnp.ndarray) -> jnp.ndarray:
 
 
 # @jax.jit
-def _nearest_cluster_distances(X: jnp.ndarray, inds: jnp.ndarray = None) -> jnp.ndarray:
+def _nearest_cluster_distances(X: jnp.ndarray, inds: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
     """Calculate the mean nearest-cluster distance for observation i."""
 
     def _body_fn(inds):

--- a/src/scib_metrics/utils/_silhouette.py
+++ b/src/scib_metrics/utils/_silhouette.py
@@ -56,7 +56,7 @@ def _nearest_cluster_distances(X: jnp.ndarray, inds: jnp.ndarray = None) -> jnp.
 
 
 @jax.jit
-def _nearest_cluster_distance_block(subset_a: jnp.ndarray, subset_b: jnp.ndarray) -> Union[jnp.ndarray, jnp.ndarray]:
+def _nearest_cluster_distance_block(subset_a: jnp.ndarray, subset_b: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
     mask_a = subset_a.sum(1) != 0
     mask_b = subset_b.sum(1) != 0
     full_mask = jnp.outer(mask_a, mask_b)

--- a/src/scib_metrics/utils/_silhouette.py
+++ b/src/scib_metrics/utils/_silhouette.py
@@ -67,6 +67,7 @@ def _format_data(X: np.ndarray, labels: np.ndarray) -> Tuple[jnp.ndarray, jnp.nd
     The padding ensures each label has the same number of cells, which helps
     reduce the number of jit compilations that occur.
     """
+    # TODO(adamgayoso): Make this jittable
     new_xs = []
     cumulative_mask = []
     _, largest_counts = np.unique(labels, return_counts=True)

--- a/src/scib_metrics/utils/_silhouette.py
+++ b/src/scib_metrics/utils/_silhouette.py
@@ -122,6 +122,8 @@ def silhouette_samples(X: np.ndarray, labels: np.ndarray) -> np.ndarray:
     Code inspired by:
     https://github.com/maxschelski/pytorch-cluster-metrics/
 
+    Implements :func:`sklearn.metrics.silhouette_samples`.
+
     Parameters
     ----------
     X

--- a/src/scib_metrics/utils/_silhouette.py
+++ b/src/scib_metrics/utils/_silhouette.py
@@ -154,10 +154,4 @@ def silhouette_samples(X: np.ndarray, labels: np.ndarray) -> np.ndarray:
     inter_dist = jnp.zeros_like(inter_dist_shuffled)
     inter_dist = inter_dist.at[remapped_inds].set(inter_dist_shuffled)
 
-    # inter_dist_array_a_b = jnp.inf * jnp.ones((n_labels, n_labels, X.shape[1]))
-    # inter_dist_array_a_b = inter_dist_array_a_b.at[inter_inds].set(inter_dist_a_b)
-    # # (padded cells,)
-    # inter_dist_array_a_b = jnp.min(inter_dist_array_a_b, axis=1).ravel()
-    # inter_dist_array_a_b = inter_dist_array_a_b[cumulative_mask]
-
     return jax.device_get((inter_dist - intra_dist) / jnp.maximum(intra_dist, inter_dist))

--- a/src/scib_metrics/utils/_silhouette.py
+++ b/src/scib_metrics/utils/_silhouette.py
@@ -53,13 +53,6 @@ def _nearest_cluster_distances(X: jnp.ndarray, inds: jnp.ndarray = None) -> jnp.
         return carry, _nearest_cluster_distance_block(X[i], X[j])
 
     _, inter_dist = jax.lax.scan(_body_fn, carry, (inds[0], inds[1]))
-    # inter_dist_a = []
-    # inter_dist_b = []
-    # for i, j in zip(inds[0], inds[1]):
-    #     res = _nearest_cluster_distance_block(X[i], X[j])
-    #     inter_dist_a.append(res[0])
-    #     inter_dist_b.append(res[1])
-    # return jnp.stack(inter_dist_a), jnp.stack(inter_dist_b)
     return inter_dist
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,6 +6,7 @@ import pandas as pd
 from harmonypy import compute_lisi as harmonypy_lisi
 from scipy.sparse import csr_matrix
 from scipy.spatial.distance import cdist as sp_cdist
+from scipy.spatial.distance import pdist, squareform
 from sklearn.metrics import silhouette_samples as sk_silhouette_samples
 from sklearn.neighbors import NearestNeighbors
 
@@ -39,6 +40,11 @@ def test_cdist():
     x = jnp.array([[1, 2], [3, 4]])
     y = jnp.array([[5, 6], [7, 8]])
     assert np.allclose(scib_metrics.utils.cdist(x, y), sp_cdist(x, y))
+
+
+def test_pdist():
+    x = jnp.array([[1, 2], [3, 4]])
+    assert np.allclose(scib_metrics.utils.pdist_squareform(x), squareform(pdist(x)))
 
 
 def test_silhouette_samples():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -11,6 +11,8 @@ from sklearn.neighbors import NearestNeighbors
 
 import scib_metrics
 
+scib_metrics.settings.jax_fix_no_kernel_image()
+
 sys.path.append("../src/")
 
 


### PR DESCRIPTION
We can ironically reduce complexity by making each cell type the same shape (cells by features). To do so we pad zeros so each cell type has the number of cells of the most frequent cell type. Then we mask sums and means to ignore the padded zeros when necessary.

Compile time is way down now, on the gaming computer it's about 1/5 of the previous time.