### PR TITLE
Update one_hot function

### DIFF
--- a/src/scib_metrics/utils/_utils.py
+++ b/src/scib_metrics/utils/_utils.py
@@ -33,7 +33,7 @@ def one_hot(y: NdArray, n_classes: Optional[int] = None) -> jnp.ndarray:
     one_hot: jnp.ndarray
         Array of shape (n_cells, n_classes).
     """
-    n_classes = n_classes or jnp.max(y) + 1
+    n_classes = n_classes or int(jnp.max(y) + 1)
     return nn.one_hot(jnp.ravel(y), n_classes)
 
 


### PR DESCRIPTION
## Changes
The function one_hot has a bug: n_classes returns a Array of type jaxlib.xla_extension.ArrayImpl which results in an error! Resolve it by transforming to int.

## Related issues
- https://github.com/YosefLab/scib-metrics/issues/105