### PR TITLE
Speedup `Benchmarker.prepare` (`compute_connectivities_umap`)

### DIFF
--- a/src/scib_metrics/benchmark/_core.py
+++ b/src/scib_metrics/benchmark/_core.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 
 import scib_metrics
 from scib_metrics.nearest_neighbors import NeighborsOutput, pynndescent
+from scib_metrics.utils._utils import compute_connectivities_umap
 
 Kwargs = dict[str, Any]
 MetricType = Union[bool, Kwargs]
@@ -190,7 +191,7 @@ class Benchmarker:
                 )
             indices, distances = neigh_output.indices, neigh_output.distances
             for n in self._neighbor_values:
-                sp_distances, sp_conns = sc.neighbors._compute_connectivities_umap(
+                sp_distances, sp_conns = compute_connectivities_umap(
                     indices[:, :n], distances[:, :n], ad.n_obs, n_neighbors=n
                 )
                 ad.obsp[f"{n}_connectivities"] = sp_conns

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+import time
+
+import numpy as np
+import pytest
+import scanpy as sc
+from sklearn.neighbors import NearestNeighbors
+
+from scib_metrics.utils._utils import compute_connectivities_umap
+from tests.utils.data import dummy_benchmarker_adata
+
+
+@pytest.mark.parametrize("n", [5, 10, 20, 21])
+def test_compute_connectivities_umap(n):
+    adata, embedding_keys, *_ = dummy_benchmarker_adata()
+    neigh = NearestNeighbors(n_neighbors=25).fit(adata.obsm[embedding_keys[0]])
+    dist, ind = neigh.kneighbors()
+    new_dist, new_connect = compute_connectivities_umap(ind[:, :n], dist[:, :n], adata.n_obs, n_neighbors=n)
+    sc_dist, sc_connect = sc.neighbors._compute_connectivities_umap(ind[:, :n], dist[:, :n], adata.n_obs, n_neighbors=n)
+    assert (new_dist == sc_dist).todense().all()
+    assert (new_connect == sc_connect).todense().all()
+
+
+def test_timing_compute_connectivities_umap():
+    n_obs = 10_000
+    X = np.random.normal(size=(n_obs, 10))
+    neigh = NearestNeighbors(n_neighbors=90).fit(X)
+    dist, ind = neigh.kneighbors()
+
+    new_start = time.perf_counter()
+    compute_connectivities_umap(ind, dist, n_obs, n_neighbors=90)
+    new_end = time.perf_counter()
+
+    sc_start = time.perf_counter()
+    sc.neighbors._compute_connectivities_umap(ind, dist, n_obs, n_neighbors=90)
+    sc_end = time.perf_counter()
+
+    assert new_end - new_start < sc_end - sc_start
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Thanks for the great package!

Unfortunately `Benchmarker.prepare()` is very slow due to currently released scanpy code:
`sc.neighbors._compute_connectivities_umap` is highly inefficient (see [this monster](https://github.com/scverse/scanpy/blob/1.9.6/scanpy/neighbors/__init__.py#L355)).

One iteration of the KNN calculation takes 2:30h for 7 Million cells. A large part of this time is spent in `sc.neighbors._compute_connectivities_umap`.

I see two solutions:
**A Use the approach proposed in this PR**
**B Use new scanpy code not yet released but already on main**

## A This PR
The solution in this PR offers the following speedup:
![image](https://github.com/YosefLab/scib-metrics/assets/43600842/d9282bf7-79b1-4bcb-b832-ec571da729ca)

## B Unreleased Scanpy code
The Neighbors scanpy code on main has been thoroughly refactored by @Zethson and likely offers a way to do this efficiently. For example `scanpy.neighbors._common._get_sparse_matrix_from_indices_distances` looks promising. I can look more into this if there's interest.

What do you think @Zethson @adamgayoso 