### PR TITLE
add progress bar arg to benchmarker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning][].
 
 ## 0.6.0 (unreleased)
 
+### Added
+
+-   Add `progress_bar` argument to {class}`scib_metrics.benchmark.Benchmarker` {pr}`152`.
+
 ## 0.5.1 (2024-02-23)
 
 ### Changed


### PR DESCRIPTION
Added `progress_bar` argument that lets users disable the progress bar in `Benchmarker`. I also noticed that the progress bar style does not adjust based on the settings - filed an issue here: #153. It might also make sense to allow `None` for `settings.progress_bar_style` and then disable it directly if so. 